### PR TITLE
Add execution worker pool

### DIFF
--- a/runner/catalog_api_test.go
+++ b/runner/catalog_api_test.go
@@ -42,9 +42,8 @@ func (suite *CatalogApiTestCase) Test_GetCatalogTest() {
 	mockRunnerService := new(MockRunnerService)
 	mockRunnerService.On("GetCatalog").Return(returnedCatalog)
 
-	deps := Dependencies{
-		mockRunnerService,
-	}
+	deps := setupTestDependencies()
+	deps.runnerService = mockRunnerService
 
 	app, err := NewAppWithDeps(suite.config, deps)
 	if err != nil {

--- a/runner/execution_api.go
+++ b/runner/execution_api.go
@@ -1,0 +1,25 @@
+package runner
+
+import (
+	"github.com/gin-gonic/gin"
+)
+
+func ExecutionHandler(runnerService RunnerService) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var r *ExecutionEvent
+
+		if err := c.BindJSON(&r); err != nil {
+			c.Error(err)
+			c.AbortWithStatusJSON(500, gin.H{"status": "nok", "message": err.Error()})
+			return
+		}
+
+		if err := runnerService.ScheduleExecution(r); err != nil {
+			c.Error(err)
+			c.AbortWithStatusJSON(500, gin.H{"status": "nok", "message": err.Error()})
+			return
+		}
+
+		c.JSON(202, map[string]string{"status": "ok"})
+	}
+}

--- a/runner/health_api_test.go
+++ b/runner/health_api_test.go
@@ -40,9 +40,8 @@ func (suite *HealthApiTestCase) Test_ApiReadyTest() {
 	mockRunnerService := new(MockRunnerService)
 	mockRunnerService.On("IsCatalogReady").Return(true)
 
-	deps := Dependencies{
-		mockRunnerService,
-	}
+	deps := setupTestDependencies()
+	deps.runnerService = mockRunnerService
 
 	app, err := NewAppWithDeps(suite.config, deps)
 	if err != nil {

--- a/runner/runner_mock.go
+++ b/runner/runner_mock.go
@@ -23,6 +23,20 @@ func (_m *MockRunnerService) BuildCatalog() error {
 	return r0
 }
 
+// Execute provides a mock function with given fields: e
+func (_m *MockRunnerService) Execute(e *ExecutionEvent) error {
+	ret := _m.Called(e)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*ExecutionEvent) error); ok {
+		r0 = rf(e)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // GetCatalog provides a mock function with given fields:
 func (_m *MockRunnerService) GetCatalog() map[string]*Catalog {
 	ret := _m.Called()
@@ -39,6 +53,22 @@ func (_m *MockRunnerService) GetCatalog() map[string]*Catalog {
 	return r0
 }
 
+// GetChannel provides a mock function with given fields:
+func (_m *MockRunnerService) GetChannel() chan *ExecutionEvent {
+	ret := _m.Called()
+
+	var r0 chan *ExecutionEvent
+	if rf, ok := ret.Get(0).(func() chan *ExecutionEvent); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(chan *ExecutionEvent)
+		}
+	}
+
+	return r0
+}
+
 // IsCatalogReady provides a mock function with given fields:
 func (_m *MockRunnerService) IsCatalogReady() bool {
 	ret := _m.Called()
@@ -48,6 +78,20 @@ func (_m *MockRunnerService) IsCatalogReady() bool {
 		r0 = rf()
 	} else {
 		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
+// ScheduleExecution provides a mock function with given fields: e
+func (_m *MockRunnerService) ScheduleExecution(e *ExecutionEvent) error {
+	ret := _m.Called(e)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*ExecutionEvent) error); ok {
+		r0 = rf(e)
+	} else {
+		r0 = ret.Error(0)
 	}
 
 	return r0

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -84,6 +84,24 @@ func (suite *RunnerTestCase) Test_BuildCatalog() {
 	suite.Equal(expectedMap, suite.runnerService.GetCatalog())
 }
 
+func (suite *RunnerTestCase) Test_ScheduleExecution() {
+	execution := &ExecutionEvent{ID: 1}
+	err := suite.runnerService.ScheduleExecution(execution)
+	suite.NoError(err)
+	suite.Equal(execution, <-suite.runnerService.GetChannel())
+}
+
+func (suite *RunnerTestCase) Test_ScheduleExecution_Full() {
+	ch := suite.runnerService.GetChannel()
+	for _, index := range [executionChannelSize]int64{} {
+		ch <- &ExecutionEvent{ID: index}
+	}
+
+	execution := &ExecutionEvent{ID: 1}
+	err := suite.runnerService.ScheduleExecution(execution)
+	suite.EqualError(err, "Cannot process more executions")
+}
+
 // TODO: This test could be improved to check the definitve ansible files structure
 // once we have something fixed
 func (suite *RunnerTestCase) Test_CreateAnsibleFiles() {

--- a/runner/test_helpers.go
+++ b/runner/test_helpers.go
@@ -1,0 +1,11 @@
+package runner
+
+import (
+	"github.com/gin-gonic/gin"
+)
+
+func setupTestDependencies() Dependencies {
+	return Dependencies{
+		webEngine: gin.Default(),
+	}
+}

--- a/runner/worker_pool.go
+++ b/runner/worker_pool.go
@@ -1,0 +1,55 @@
+package runner
+
+import (
+	"context"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/sync/semaphore"
+)
+
+var workersNumber int64 = 3
+var drainTimeout = time.Second * 5
+
+type ExecutionWorkerPool struct {
+	runnerService RunnerService
+}
+
+func NewExecutionWorkerPool(runnerService RunnerService) *ExecutionWorkerPool {
+	return &ExecutionWorkerPool{
+		runnerService: runnerService,
+	}
+}
+
+// Run runs a pool of workers to process the execution requests
+func (e *ExecutionWorkerPool) Run(ctx context.Context) {
+	log.Infof("Starting execution pool. Workers limit: %d", workersNumber)
+	sem := semaphore.NewWeighted(workersNumber)
+	channel := e.runnerService.GetChannel()
+
+	for {
+		select {
+		case execution := <-channel:
+			if err := sem.Acquire(ctx, 1); err != nil {
+				log.Debugf("Discarding execution: %d, shutting down already.", execution.ID)
+				break
+			}
+
+			go func() {
+				defer sem.Release(1)
+				e.runnerService.Execute(execution)
+			}()
+		case <-ctx.Done():
+			log.Infof("Projectors worker pool is shutting down... Waiting for active workers to drain.")
+
+			ctx, cancel := context.WithTimeout(context.Background(), drainTimeout)
+			defer cancel()
+
+			if err := sem.Acquire(ctx, workersNumber); err != nil {
+				log.Warnf("Timed out while draining workers: %v", err)
+			}
+
+			return
+		}
+	}
+}

--- a/runner/worker_pool_test.go
+++ b/runner/worker_pool_test.go
@@ -1,0 +1,45 @@
+package runner
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	mock "github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+)
+
+type WorkerPoolTestCase struct {
+	suite.Suite
+}
+
+func TestWorkerPoolTestCase(t *testing.T) {
+	suite.Run(t, new(WorkerPoolTestCase))
+}
+
+func (suite *WorkerPoolTestCase) Test_Run() {
+	channel := make(chan *ExecutionEvent)
+	execution := &ExecutionEvent{ID: 1}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	mockRunnerService := new(MockRunnerService)
+	mockRunnerService.On("Execute", mock.Anything).Run(func(args mock.Arguments) {
+		wg.Done()
+	}).Return(nil)
+	mockRunnerService.On("GetChannel").Return(channel)
+
+	workerPool := NewExecutionWorkerPool(mockRunnerService)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go workerPool.Run(ctx)
+	channel <- execution
+	channel <- execution
+
+	wg.Wait()
+
+	mockRunnerService.AssertNumberOfCalls(suite.T(), "Execute", 2)
+	cancel()
+}


### PR DESCRIPTION
Executions worker pool. It follows the same approach we used in the Collector data pipeline in the past.

The PR adds:

- New `/api/execute` endpoint to schedule new execution events. By now, it only accepts a `{"id": 1}` kind of struct. We will decide the contract between the server and runner later on, but I assume an ID will come.
- Once execution requests are coming, they are schedule. I have updated the channel to be a buffered one. This way, we can control if the channel queue is empty or not, and we can return back `not possible to execute` kind of answers. **The channel size is not the workers number. It is only used to know if we need to reply with errored message to the POST request or not**
- Some additional test related code, as setup the test environment.

The PR doesn't implement yet the checks execution. It just have a dummy `Execute` function.

