### PR TITLE
Execute playbook with the incoming clusters data

### DIFF
--- a/runner/ansiblerunner.go
+++ b/runner/ansiblerunner.go
@@ -12,6 +12,7 @@ import (
 const (
 	CatalogDestination   = "CATALOG_DESTINATION"
 	TrentoCallbacksUrl   = "TRENTO_CALLBACKS_URL"
+	TrentoExecutionID    = "TRENTO_EXECUTION_ID"
 	AnsibleConfigFileEnv = "ANSIBLE_CONFIG"
 )
 
@@ -70,6 +71,10 @@ func (a *AnsibleRunner) SetCatalogDestination(destination string) {
 
 func (a *AnsibleRunner) SetTrentoCallbacksUrl(callbacksUrl string) {
 	a.setEnv(TrentoCallbacksUrl, callbacksUrl)
+}
+
+func (a *AnsibleRunner) SetTrentoExecutionID(executionID string) {
+	a.setEnv(TrentoExecutionID, executionID)
 }
 
 func (a *AnsibleRunner) RunPlaybook() error {

--- a/runner/execution_event.go
+++ b/runner/execution_event.go
@@ -5,19 +5,19 @@ import (
 )
 
 type ExecutionEvent struct {
-	ID       uuid.UUID  `json:"id" binding:"required"`
+	ID       uuid.UUID  `json:"execution_id" binding:"required"`
 	Clusters []*Cluster `json:"clusters" binding:"required"`
 }
 
 type Cluster struct {
-	ID       uuid.UUID `json:"id" binding:"required"`
+	ID       uuid.UUID `json:"cluster_id" binding:"required"`
 	Provider string    `json:"provider" binding:"required"`
 	Checks   []string  `json:"checks" binding:"required"`
 	Hosts    []*Host   `json:"hosts" binding:"required"`
 }
 
 type Host struct {
-	Name    string `json:"name" binding:"required"`
-	Address string `json:"address" binding:"required"`
-	User    string `json:"user" binding:"required"`
+	ID      uuid.UUID `json:"host_id" binding:"required"`
+	Address string    `json:"address" binding:"required"`
+	User    string    `json:"user" binding:"required"`
 }

--- a/runner/execution_event.go
+++ b/runner/execution_event.go
@@ -1,0 +1,23 @@
+package runner
+
+import (
+	"github.com/google/uuid"
+)
+
+type ExecutionEvent struct {
+	ID       uuid.UUID  `json:"id" binding:"required"`
+	Clusters []*Cluster `json:"clusters" binding:"required"`
+}
+
+type Cluster struct {
+	ID       uuid.UUID `json:"id" binding:"required"`
+	Provider string    `json:"provider" binding:"required"`
+	Checks   []string  `json:"checks" binding:"required"`
+	Hosts    []*Host   `json:"hosts" binding:"required"`
+}
+
+type Host struct {
+	Name    string `json:"name" binding:"required"`
+	Address string `json:"address" binding:"required"`
+	User    string `json:"user" binding:"required"`
+}

--- a/runner/inventory.go
+++ b/runner/inventory.go
@@ -74,7 +74,7 @@ func NewClusterInventoryContent(e *ExecutionEvent) (*InventoryContent, error) {
 
 		for _, host := range cluster.Hosts {
 			node := &Node{
-				Name:        host.Name,
+				Name:        host.ID.String(),
 				AnsibleHost: host.Address,
 				AnsibleUser: host.User,
 				Variables:   make(map[string]interface{}),

--- a/runner/inventory.go
+++ b/runner/inventory.go
@@ -3,11 +3,10 @@ package runner
 import (
 	"encoding/json"
 	"os"
+	"path"
 	"text/template"
 
 	log "github.com/sirupsen/logrus"
-
-	"github.com/trento-project/runner/api"
 )
 
 type InventoryContent struct {
@@ -38,19 +37,22 @@ const (
 {{- end }}
 {{- end }}
 `
-	DefaultUser           string = "root"
 	clusterSelectedChecks string = "cluster_selected_checks"
+	provider              string = "provider"
 )
 
 func CreateInventory(destination string, content *InventoryContent) error {
 	t := template.Must(template.New("").Parse(inventoryTemplate))
 
+	if err := os.MkdirAll(path.Dir(destination), 0755); err != nil {
+		return err
+	}
+
 	f, err := os.Create(destination)
 	if err != nil {
 		return err
 	}
-	err = t.Execute(f, content)
-	if err != nil {
+	if err := t.Execute(f, content); err != nil {
 		return nil
 	}
 	f.Close()
@@ -58,20 +60,15 @@ func CreateInventory(destination string, content *InventoryContent) error {
 	return nil
 }
 
-func NewClusterInventoryContent(trentoApi api.TrentoApiService) (*InventoryContent, error) {
+func NewClusterInventoryContent(e *ExecutionEvent) (*InventoryContent, error) {
 	content := &InventoryContent{}
 
-	clustersSettings, err := trentoApi.GetClustersSettings()
-	if err != nil {
-		return nil, err
-	}
-
-	for _, cluster := range clustersSettings {
+	for _, cluster := range e.Clusters {
 		nodes := []*Node{}
 
-		jsonSelectedChecks, err := json.Marshal(cluster.SelectedChecks)
+		jsonChecks, err := json.Marshal(cluster.Checks)
 		if err != nil {
-			log.Errorf("error marshalling the cluster %s selected checks: %s", cluster.ID, err)
+			log.Errorf("error marshalling the cluster %s selected checks: %s", cluster.ID.String(), err)
 			continue
 		}
 
@@ -83,11 +80,12 @@ func NewClusterInventoryContent(trentoApi api.TrentoApiService) (*InventoryConte
 				Variables:   make(map[string]interface{}),
 			}
 
-			node.Variables[clusterSelectedChecks] = string(jsonSelectedChecks)
+			node.Variables[clusterSelectedChecks] = string(jsonChecks)
+			node.Variables[provider] = cluster.Provider
 
 			nodes = append(nodes, node)
 		}
-		group := &Group{Name: cluster.ID, Nodes: nodes}
+		group := &Group{Name: cluster.ID.String(), Nodes: nodes}
 
 		content.Groups = append(content.Groups, group)
 	}

--- a/runner/inventory_test.go
+++ b/runner/inventory_test.go
@@ -6,10 +6,8 @@ import (
 	"path"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/suite"
-
-	webApi "github.com/trento-project/runner/api"
-	apiMocks "github.com/trento-project/runner/api/mocks"
 )
 
 type InventoryTestSuite struct {
@@ -94,21 +92,60 @@ func (suite *InventoryTestSuite) Test_CreateInventory() {
 }
 
 func (suite *InventoryTestSuite) Test_NewClusterInventoryContent() {
-	apiInst := new(apiMocks.TrentoApiService)
+	cluster1 := uuid.New()
+	cluster2 := uuid.New()
+	executionEvent := &ExecutionEvent{
+		ID: uuid.New(),
+		Clusters: []*Cluster{
+			&Cluster{
+				ID:       cluster1,
+				Provider: "azure",
+				Checks:   []string{"check1", "check2"},
+				Hosts: []*Host{
+					&Host{
+						Name:    "node1",
+						Address: "192.168.10.1",
+						User:    "user1",
+					},
+					&Host{
+						Name:    "node2",
+						Address: "192.168.10.2",
+						User:    "user2",
+					},
+				},
+			},
+			&Cluster{
+				ID:       cluster2,
+				Provider: "azure",
+				Checks:   []string{"check3", "check4"},
+				Hosts: []*Host{
+					&Host{
+						Name:    "node3",
+						Address: "192.168.10.3",
+						User:    "user3",
+					},
+					&Host{
+						Name:    "node4",
+						Address: "192.168.10.4",
+						User:    "user4",
+					},
+				},
+			},
+		},
+	}
 
-	apiInst.On("GetClustersSettings").Return(mockedClustersSettings(), nil)
-
-	content, err := NewClusterInventoryContent(apiInst)
+	content, err := NewClusterInventoryContent(executionEvent)
 
 	expectedContent := &InventoryContent{
 		Groups: []*Group{
 			&Group{
-				Name: "cluster1",
+				Name: cluster1.String(),
 				Nodes: []*Node{
 					&Node{
 						Name: "node1",
 						Variables: map[string]interface{}{
 							"cluster_selected_checks": "[\"check1\",\"check2\"]",
+							"provider":                "azure",
 						},
 						AnsibleHost: "192.168.10.1",
 						AnsibleUser: "user1",
@@ -117,6 +154,7 @@ func (suite *InventoryTestSuite) Test_NewClusterInventoryContent() {
 						Name: "node2",
 						Variables: map[string]interface{}{
 							"cluster_selected_checks": "[\"check1\",\"check2\"]",
+							"provider":                "azure",
 						},
 						AnsibleHost: "192.168.10.2",
 						AnsibleUser: "user2",
@@ -124,23 +162,25 @@ func (suite *InventoryTestSuite) Test_NewClusterInventoryContent() {
 				},
 			},
 			&Group{
-				Name: "cluster2",
+				Name: cluster2.String(),
 				Nodes: []*Node{
 					&Node{
 						Name: "node3",
 						Variables: map[string]interface{}{
 							"cluster_selected_checks": "[\"check3\",\"check4\"]",
+							"provider":                "azure",
 						},
 						AnsibleHost: "192.168.10.3",
-						AnsibleUser: "clouduser",
+						AnsibleUser: "user3",
 					},
 					&Node{
 						Name: "node4",
 						Variables: map[string]interface{}{
 							"cluster_selected_checks": "[\"check3\",\"check4\"]",
+							"provider":                "azure",
 						},
-						AnsibleHost: "",
-						AnsibleUser: "root",
+						AnsibleHost: "192.168.10.4",
+						AnsibleUser: "user4",
 					},
 				},
 			},
@@ -149,42 +189,4 @@ func (suite *InventoryTestSuite) Test_NewClusterInventoryContent() {
 
 	suite.NoError(err)
 	suite.ElementsMatch(expectedContent.Groups, content.Groups)
-	apiInst.AssertExpectations(suite.T())
-}
-
-func mockedClustersSettings() webApi.ClustersSettingsResponse {
-	return webApi.ClustersSettingsResponse{
-		{
-			ID:             "cluster1",
-			SelectedChecks: []string{"check1", "check2"},
-			Hosts: []*webApi.HostConnection{
-				{
-					Name:    "node1",
-					Address: "192.168.10.1",
-					User:    "user1",
-				},
-				{
-					Name:    "node2",
-					Address: "192.168.10.2",
-					User:    "user2",
-				},
-			},
-		},
-		{
-			ID:             "cluster2",
-			SelectedChecks: []string{"check3", "check4"},
-			Hosts: []*webApi.HostConnection{
-				{
-					Name:    "node3",
-					Address: "192.168.10.3",
-					User:    "clouduser",
-				},
-				{
-					Name:    "node4",
-					Address: "",
-					User:    "root",
-				},
-			},
-		},
-	}
 }

--- a/runner/inventory_test.go
+++ b/runner/inventory_test.go
@@ -94,6 +94,11 @@ func (suite *InventoryTestSuite) Test_CreateInventory() {
 func (suite *InventoryTestSuite) Test_NewClusterInventoryContent() {
 	cluster1 := uuid.New()
 	cluster2 := uuid.New()
+	host1 := uuid.New()
+	host2 := uuid.New()
+	host3 := uuid.New()
+	host4 := uuid.New()
+
 	executionEvent := &ExecutionEvent{
 		ID: uuid.New(),
 		Clusters: []*Cluster{
@@ -103,12 +108,12 @@ func (suite *InventoryTestSuite) Test_NewClusterInventoryContent() {
 				Checks:   []string{"check1", "check2"},
 				Hosts: []*Host{
 					&Host{
-						Name:    "node1",
+						ID:      host1,
 						Address: "192.168.10.1",
 						User:    "user1",
 					},
 					&Host{
-						Name:    "node2",
+						ID:      host2,
 						Address: "192.168.10.2",
 						User:    "user2",
 					},
@@ -120,12 +125,12 @@ func (suite *InventoryTestSuite) Test_NewClusterInventoryContent() {
 				Checks:   []string{"check3", "check4"},
 				Hosts: []*Host{
 					&Host{
-						Name:    "node3",
+						ID:      host3,
 						Address: "192.168.10.3",
 						User:    "user3",
 					},
 					&Host{
-						Name:    "node4",
+						ID:      host4,
 						Address: "192.168.10.4",
 						User:    "user4",
 					},
@@ -142,7 +147,7 @@ func (suite *InventoryTestSuite) Test_NewClusterInventoryContent() {
 				Name: cluster1.String(),
 				Nodes: []*Node{
 					&Node{
-						Name: "node1",
+						Name: host1.String(),
 						Variables: map[string]interface{}{
 							"cluster_selected_checks": "[\"check1\",\"check2\"]",
 							"provider":                "azure",
@@ -151,7 +156,7 @@ func (suite *InventoryTestSuite) Test_NewClusterInventoryContent() {
 						AnsibleUser: "user1",
 					},
 					&Node{
-						Name: "node2",
+						Name: host2.String(),
 						Variables: map[string]interface{}{
 							"cluster_selected_checks": "[\"check1\",\"check2\"]",
 							"provider":                "azure",
@@ -165,7 +170,7 @@ func (suite *InventoryTestSuite) Test_NewClusterInventoryContent() {
 				Name: cluster2.String(),
 				Nodes: []*Node{
 					&Node{
-						Name: "node3",
+						Name: host3.String(),
 						Variables: map[string]interface{}{
 							"cluster_selected_checks": "[\"check3\",\"check4\"]",
 							"provider":                "azure",
@@ -174,7 +179,7 @@ func (suite *InventoryTestSuite) Test_NewClusterInventoryContent() {
 						AnsibleUser: "user3",
 					},
 					&Node{
-						Name: "node4",
+						Name: host4.String(),
 						Variables: map[string]interface{}{
 							"cluster_selected_checks": "[\"check3\",\"check4\"]",
 							"provider":                "azure",

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -193,6 +193,8 @@ func (suite *RunnerTestCase) Test_NewAnsibleCheckRunner() {
 
 	executionID := uuid.New()
 	clusterID := uuid.New()
+	host1ID := uuid.New()
+	host2ID := uuid.New()
 	executionEvent := &ExecutionEvent{
 		ID: executionID,
 		Clusters: []*Cluster{
@@ -202,12 +204,12 @@ func (suite *RunnerTestCase) Test_NewAnsibleCheckRunner() {
 				Checks:   []string{"check1", "check2"},
 				Hosts: []*Host{
 					&Host{
-						Name:    "node1",
+						ID:      host1ID,
 						Address: "192.168.10.1",
 						User:    "user1",
 					},
 					&Host{
-						Name:    "node2",
+						ID:      host2ID,
 						Address: "192.168.10.2",
 						User:    "user2",
 					},
@@ -234,10 +236,10 @@ func (suite *RunnerTestCase) Test_NewAnsibleCheckRunner() {
 	inventoryContent, err := ioutil.ReadFile(inventoryFile)
 	expectedFile := "\n" +
 		"[%s]\n" +
-		"node1 ansible_host=192.168.10.1 ansible_user=user1 cluster_selected_checks=[\"check1\",\"check2\"] provider=azure \n" +
-		"node2 ansible_host=192.168.10.2 ansible_user=user2 cluster_selected_checks=[\"check1\",\"check2\"] provider=azure \n"
+		"%s ansible_host=192.168.10.1 ansible_user=user1 cluster_selected_checks=[\"check1\",\"check2\"] provider=azure \n" +
+		"%s ansible_host=192.168.10.2 ansible_user=user2 cluster_selected_checks=[\"check1\",\"check2\"] provider=azure \n"
 
 	suite.NoError(err)
 	suite.Equal(expectedChecksRunner, a)
-	suite.Equal(fmt.Sprintf(expectedFile, clusterID.String()), string(inventoryContent))
+	suite.Equal(fmt.Sprintf(expectedFile, clusterID.String(), host1ID.String(), host2ID.String()), string(inventoryContent))
 }

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -109,8 +109,25 @@ func (suite *RunnerTestCase) Test_ScheduleExecution_Full() {
 }
 
 func (suite *RunnerTestCase) Test_Execute() {
+	os.MkdirAll(path.Join(suite.ansibleDir, "ansible"), 0755)
+	os.Create(path.Join(suite.ansibleDir, "ansible/check.yml"))
+	defer os.RemoveAll(suite.ansibleDir)
+
 	dummyID := uuid.New()
 	suite.callbacksClient.On("Callback", dummyID, "execution_started", nil).Return(nil)
+
+	cmd := exec.Command("ls") // Dummy command to execute something
+
+	mockCommand := new(mocks.CustomCommand)
+	customExecCommand = mockCommand.Execute
+
+	mockCommand.On(
+		"Execute",
+		"ansible-playbook",
+		path.Join(suite.ansibleDir, "ansible/check.yml"),
+		fmt.Sprintf("--inventory=%s/ansible/inventories/%s/ansible_hosts", suite.ansibleDir, dummyID.String()),
+		"--check",
+	).Return(cmd)
 
 	execution := &ExecutionEvent{ID: dummyID}
 	err := suite.runnerService.Execute(execution)
@@ -164,23 +181,63 @@ func (suite *RunnerTestCase) Test_NewAnsibleMetaRunner() {
 }
 
 func (suite *RunnerTestCase) Test_NewAnsibleCheckRunner() {
+	tmpDir, _ := ioutil.TempDir(os.TempDir(), "trentotest")
+	os.MkdirAll(path.Join(tmpDir, "ansible"), 0755)
+	os.Create(path.Join(tmpDir, "ansible/check.yml"))
+	defer os.RemoveAll(tmpDir)
 
 	cfg := &Config{
 		CallbacksUrl:  "http://192.168.1.1:8000/api/runner/callbacks",
-		AnsibleFolder: TestAnsibleFolder,
+		AnsibleFolder: tmpDir,
 	}
 
-	a, err := NewAnsibleCheckRunner(cfg)
+	executionID := uuid.New()
+	clusterID := uuid.New()
+	executionEvent := &ExecutionEvent{
+		ID: executionID,
+		Clusters: []*Cluster{
+			&Cluster{
+				ID:       clusterID,
+				Provider: "azure",
+				Checks:   []string{"check1", "check2"},
+				Hosts: []*Host{
+					&Host{
+						Name:    "node1",
+						Address: "192.168.10.1",
+						User:    "user1",
+					},
+					&Host{
+						Name:    "node2",
+						Address: "192.168.10.2",
+						User:    "user2",
+					},
+				},
+			},
+		},
+	}
 
-	expectedMetaRunner := &AnsibleRunner{
-		Playbook: path.Join(TestAnsibleFolder, "ansible/check.yml"),
+	a, err := NewAnsibleCheckRunner(cfg, executionEvent)
+
+	inventoryFile := path.Join(tmpDir, fmt.Sprintf("ansible/inventories/%s/ansible_hosts", executionID.String()))
+
+	expectedChecksRunner := &AnsibleRunner{
+		Playbook:  path.Join(tmpDir, "ansible/check.yml"),
+		Inventory: inventoryFile,
 		Envs: map[string]string{
-			"ANSIBLE_CONFIG":       path.Join(TestAnsibleFolder, "ansible/ansible.cfg"),
+			"ANSIBLE_CONFIG":       path.Join(tmpDir, "ansible/ansible.cfg"),
 			"TRENTO_CALLBACKS_URL": "http://192.168.1.1:8000/api/runner/callbacks",
+			"TRENTO_EXECUTION_ID":  executionID.String(),
 		},
 		Check: true,
 	}
 
+	inventoryContent, err := ioutil.ReadFile(inventoryFile)
+	expectedFile := "\n" +
+		"[%s]\n" +
+		"node1 ansible_host=192.168.10.1 ansible_user=user1 cluster_selected_checks=[\"check1\",\"check2\"] provider=azure \n" +
+		"node2 ansible_host=192.168.10.2 ansible_user=user2 cluster_selected_checks=[\"check1\",\"check2\"] provider=azure \n"
+
 	suite.NoError(err)
-	suite.Equal(expectedMetaRunner, a)
+	suite.Equal(expectedChecksRunner, a)
+	suite.Equal(fmt.Sprintf(expectedFile, clusterID.String()), string(inventoryContent))
 }


### PR DESCRIPTION
Execute the actual ansible playbook.

For that, the execution inventories are created based on the `ExecutionEvent` coming from the `/api/execute` call.

The python callbacks code has not been changed yet. This will come in a subsequent PR. By now, the callbacks just sends the old structure.

This is an example of a request:
```
{
   execution_id: "779cdd70-e9e2-58ca-b18a-bf3eb3f71244",
   clusters: [
      {
         cluster_id: "779cdd70-e9e2-58ca-b18a-bf3eb3f71244",
         provider: "azure",
         checks: [
            "156F64",
            "53D035",
            "A1244C"
         ],
         hosts: [
            {
               host_id: "779cdd70-e9e2-58ca-b18a-bf3eb3f71241",
               address: "10.162.29.43",
               user: "root"
            },
            {
               host_id: "779cdd70-e9e2-58ca-b18a-bf3eb3f71240",
               address: "10.162.30.229",
               user: "root"
            }
         ]
      },
      {
         cluster_id: "779cdd70-e9e2-58ca-b18a-bf3eb3f71245",
         provider: "azure",
         checks: [
            "845CC9",
            "24ABCB"
         ],
         hosts: [
            {
               host_id: "779cdd70-e9e2-58ca-b18a-bf3eb3f71243",
               address: "10.162.29.43",
               user: "root"
            },
            {
               host_id: "779cdd70-e9e2-58ca-b18a-bf3eb3f71246",
               address: "10.162.30.226",
               user: "root"
            }
         ]
      }
   ]
}
```