### PR TITLE
Flatten checks catalog ouptut

### DIFF
--- a/runner/ansible/roles/post-metadata/tasks/store.yml
+++ b/runner/ansible/roles/post-metadata/tasks/store.yml
@@ -14,18 +14,16 @@
 - name: Set metadata {{ id }}
   set_fact:
     metadata: |
-      {{ (metadata|default({})) | combine(
-        { provider | default('azure'):
-          { 'checks': [{
-              'id': id|string,
-              'name': name,
-              'group': group,
-              'description': description,
-              'remediation': remediation,
-              'labels': labels,
-              'implementation': implementation,
-              'premium': metadata_vars.premium|default(False)
-            }]
-          },
-        },recursive=True, list_merge='append')
+      {{ (metadata|default([])) +
+        [{
+          'id': id|string,
+          'name': name,
+          'provider': provider,
+          'group': group,
+          'description': description,
+          'remediation': remediation,
+          'labels': labels,
+          'implementation': implementation,
+          'premium': metadata_vars.premium|default(False)
+        }]
       }}

--- a/runner/catalog.go
+++ b/runner/catalog.go
@@ -4,14 +4,13 @@ const (
 	CatalogDestinationFile = "ansible/catalog.json"
 )
 
-type Catalog struct {
-	Checks []*CatalogCheck `json:"checks" binding:"required"`
-}
+type Catalog []*CatalogCheck
 
 type CatalogCheck struct {
 	ID             string `json:"id,omitempty" binding:"required"`
 	Name           string `json:"name,omitempty" binding:"required"`
-	Group          string `json:"group,omitempty" binding:"required"`
+	Group          string `json:"group" binding:"required"`
+	Provider       string `json:"provider" binding:"required"`
 	Description    string `json:"description,omitempty"`
 	Remediation    string `json:"remediation,omitempty"`
 	Implementation string `json:"implementation,omitempty"`

--- a/runner/catalog_api_test.go
+++ b/runner/catalog_api_test.go
@@ -22,20 +22,17 @@ func (suite *CatalogApiTestCase) SetupTest() {
 }
 
 func (suite *CatalogApiTestCase) Test_GetCatalogTest() {
-	returnedCatalog := map[string]*Catalog{
-		"azure": &Catalog{
-			Checks: []*CatalogCheck{
-				{
-					ID:             "156F64",
-					Name:           "1.1.1",
-					Group:          "Corosync",
-					Description:    "description azure",
-					Remediation:    "remediation",
-					Implementation: "implementation",
-					Labels:         "generic",
-					Premium:        false,
-				},
-			},
+	returnedCatalog := &Catalog{
+		&CatalogCheck{
+			ID:             "156F64",
+			Name:           "1.1.1",
+			Group:          "Corosync",
+			Provider:       "azure",
+			Description:    "description azure",
+			Remediation:    "remediation",
+			Implementation: "implementation",
+			Labels:         "generic",
+			Premium:        false,
 		},
 	}
 

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -31,7 +31,7 @@ const (
 type RunnerService interface {
 	IsCatalogReady() bool
 	BuildCatalog() error
-	GetCatalog() map[string]*Catalog
+	GetCatalog() *Catalog
 	GetChannel() chan *ExecutionEvent
 	ScheduleExecution(e *ExecutionEvent) error
 	Execute(e *ExecutionEvent) error
@@ -41,7 +41,7 @@ type runnerService struct {
 	config            *Config
 	workerPoolChannel chan *ExecutionEvent
 	callbacksClient   CallbacksClient
-	catalog           map[string]*Catalog
+	catalog           *Catalog
 	ready             bool
 }
 
@@ -77,13 +77,13 @@ func (c *runnerService) BuildCatalog() error {
 	}
 
 	// After the playbook is done, recover back the file content
-	catalogRaw, err := ioutil.ReadFile(metaRunner.Envs[CatalogDestination])
+	catalogFile, err := ioutil.ReadFile(metaRunner.Envs[CatalogDestination])
 	if err != nil {
 		log.Fatal("Error when opening the catalog file: ", err)
 	}
 
-	var catalog map[string]*Catalog
-	err = json.Unmarshal(catalogRaw, &catalog)
+	var catalog *Catalog
+	err = json.Unmarshal(catalogFile, &catalog)
 	if err != nil {
 		log.Fatal("Error during Unmarshal(): ", err)
 	}
@@ -94,7 +94,7 @@ func (c *runnerService) BuildCatalog() error {
 	return nil
 }
 
-func (c *runnerService) GetCatalog() map[string]*Catalog {
+func (c *runnerService) GetCatalog() *Catalog {
 	return c.catalog
 }
 

--- a/runner/runner_mock.go
+++ b/runner/runner_mock.go
@@ -38,15 +38,15 @@ func (_m *MockRunnerService) Execute(e *ExecutionEvent) error {
 }
 
 // GetCatalog provides a mock function with given fields:
-func (_m *MockRunnerService) GetCatalog() map[string]*Catalog {
+func (_m *MockRunnerService) GetCatalog() *Catalog {
 	ret := _m.Called()
 
-	var r0 map[string]*Catalog
-	if rf, ok := ret.Get(0).(func() map[string]*Catalog); ok {
+	var r0 *Catalog
+	if rf, ok := ret.Get(0).(func() *Catalog); ok {
 		r0 = rf()
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(map[string]*Catalog)
+			r0 = ret.Get(0).(*Catalog)
 		}
 	}
 

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -54,40 +54,34 @@ func (suite *RunnerTestCase) Test_BuildCatalog() {
 
 	err := suite.runnerService.BuildCatalog()
 
-	expectedMap := map[string]*Catalog{
-		"azure": &Catalog{
-			Checks: []*CatalogCheck{
-				{
-					ID:             "156F64",
-					Name:           "1.1.1",
-					Group:          "Corosync",
-					Description:    "description azure",
-					Remediation:    "remediation",
-					Implementation: "implementation",
-					Labels:         "generic",
-					Premium:        false,
-				},
-			},
+	expectedCatalog := &Catalog{
+		&CatalogCheck{
+			ID:             "156F64",
+			Name:           "1.1.1",
+			Group:          "Corosync",
+			Provider:       "azure",
+			Description:    "description azure",
+			Remediation:    "remediation",
+			Implementation: "implementation",
+			Labels:         "generic",
+			Premium:        false,
 		},
-		"dev": &Catalog{
-			Checks: []*CatalogCheck{
-				{
-					ID:             "156F64",
-					Name:           "1.1.1",
-					Group:          "Corosync",
-					Description:    "description dev",
-					Remediation:    "remediation",
-					Implementation: "implementation",
-					Labels:         "generic",
-					Premium:        false,
-				},
-			},
+		&CatalogCheck{
+			ID:             "156F64",
+			Name:           "1.1.1",
+			Group:          "Corosync",
+			Provider:       "dev",
+			Description:    "description dev",
+			Remediation:    "remediation",
+			Implementation: "implementation",
+			Labels:         "generic",
+			Premium:        false,
 		},
 	}
 
 	suite.NoError(err)
 	suite.Equal(true, suite.runnerService.IsCatalogReady())
-	suite.Equal(expectedMap, suite.runnerService.GetCatalog())
+	suite.Equal(expectedCatalog, suite.runnerService.GetCatalog())
 }
 
 func (suite *RunnerTestCase) Test_ScheduleExecution() {

--- a/test/fixtures/catalog.json
+++ b/test/fixtures/catalog.json
@@ -1,32 +1,24 @@
-{
-  "azure":
+[
   {
-    "checks": [
-      {
-        "group": "Corosync",
-        "name": "1.1.1",
-        "implementation": "implementation",
-        "labels": "generic",
-        "remediation": "remediation",
-        "premium": false,
-        "id": "156F64",
-        "description": "description azure"
-      }
-    ]
+    "group": "Corosync",
+    "provider": "azure",
+    "name": "1.1.1",
+    "implementation": "implementation",
+    "labels": "generic",
+    "remediation": "remediation",
+    "premium": false,
+    "id": "156F64",
+    "description": "description azure"
   },
-  "dev":
   {
-    "checks": [
-      {
-        "group": "Corosync",
-        "name": "1.1.1",
-        "implementation": "implementation",
-        "labels": "generic",
-        "remediation": "remediation",
-        "premium": false,
-        "id": "156F64",
-        "description": "description dev"
-      }
-    ]
+    "group": "Corosync",
+    "provider": "dev",
+    "name": "1.1.1",
+    "implementation": "implementation",
+    "labels": "generic",
+    "remediation": "remediation",
+    "premium": false,
+    "id": "156F64",
+    "description": "description dev"
   }
-}
+]


### PR DESCRIPTION
In order to avoid doing "complex" operations in golang, as we can make them in elixir, which is more suitable for that, thie PR flattens out the checks catalog output, so we just return a list with all the checks. 

The work of transforming this content in something the frontend consumes will be done by the server side.

Something like:

```
[
  {
    "id": "156F64",
    "name": "1.1.1",
    "group": "Corosync",
    "provider": "azure",
    ...
  },
  {
    "id": "53D035",
    "name": "1.1.1.runtime",
    "group": "Corosync",
    "provider": "azure",
    ...
  },
  {
    "id": "A1244C",
    "name": "1.1.2",
    "group": "Corosync",
    "provider": "azure",
   ...
  },
  {
    "id": "FB0E0D",
    "name": "1.1.2.runtime",
    "group": "Corosync",
    "provider": "azure",
    ...
  },
  {
    "id": "845CC9",
    ...
```