### PR TITLE
Update get catalog endpoint to return 204 when not ready

### DIFF
--- a/runner/catalog_api.go
+++ b/runner/catalog_api.go
@@ -6,6 +6,10 @@ import (
 
 func CatalogHandler(runnerService RunnerService) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		c.JSON(200, runnerService.GetCatalog())
+		if runnerService.IsCatalogReady() {
+			c.JSON(200, runnerService.GetCatalog())
+		} else {
+			c.JSON(204, nil)
+		}
 	}
 }

--- a/runner/catalog_api_test.go
+++ b/runner/catalog_api_test.go
@@ -21,7 +21,27 @@ func (suite *CatalogApiTestCase) SetupTest() {
 	suite.config = &Config{}
 }
 
-func (suite *CatalogApiTestCase) Test_GetCatalogTest() {
+func (suite *CatalogApiTestCase) Test_GetCatalogTest_NotReady() {
+	mockRunnerService := new(MockRunnerService)
+	mockRunnerService.On("IsCatalogReady").Return(false)
+
+	deps := setupTestDependencies()
+	deps.runnerService = mockRunnerService
+
+	app, err := NewAppWithDeps(suite.config, deps)
+	if err != nil {
+		suite.T().Fatal(err)
+	}
+
+	resp := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/catalog", nil)
+	app.webEngine.ServeHTTP(resp, req)
+
+	suite.Equal(204, resp.Code)
+	suite.Equal("", resp.Body.String())
+}
+
+func (suite *CatalogApiTestCase) Test_GetCatalogTest_Ready() {
 	returnedCatalog := &Catalog{
 		&CatalogCheck{
 			ID:             "156F64",
@@ -37,6 +57,7 @@ func (suite *CatalogApiTestCase) Test_GetCatalogTest() {
 	}
 
 	mockRunnerService := new(MockRunnerService)
+	mockRunnerService.On("IsCatalogReady").Return(true)
 	mockRunnerService.On("GetCatalog").Return(returnedCatalog)
 
 	deps := setupTestDependencies()


### PR DESCRIPTION
As the title says, return `204` status code in `/api/catalog` when the catalog is not ready yet.