### PR TITLE
Change container tag to rolling

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -90,8 +90,7 @@ jobs:
     env:
       REGISTRY: ghcr.io
       IMAGE_REPOSITORY: ghcr.io/${{ github.repository_owner }}/trento-runner
-      #IMAGE_TAG: "${{ (github.event_name == 'release' && github.event.release.tag_name) || (github.event_name == 'push' && github.ref_name == 'main' && 'rolling') || github.sha }}"
-      IMAGE_TAG: "dev"
+      IMAGE_TAG: "${{ (github.event_name == 'release' && github.event.release.tag_name) || (github.event_name == 'push' && github.ref_name == 'main' && 'rolling') || github.sha }}"
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
This PR changes the container tag from `trento-runner:dev` to `trento-runner:(rolling|0.x.x)` overwriting the legacy package