### PR TITLE
Check-rework for corosync and SBD

### DIFF
--- a/runner/ansible/roles/checks/1.1.1/tasks/main.yml
+++ b/runner/ansible/roles/checks/1.1.1/tasks/main.yml
@@ -3,9 +3,10 @@
 - name: "{{ name }}.check"
   lineinfile:
     path: /etc/corosync/corosync.conf
-    regexp: '^(\s+){{ key_name }}:'
-    line: "\t{{ key_name }}: {{ expected[name] }}"
-    insertafter: 'totem {'
+    regexp: '^(\s*){{ key_name }}:(\s*)\S*(\s)*$'
+    line: '\g<1>{{ key_name }}:\g<2>{{ expected[name] }}\g<3>'
+    backrefs: yes
+    #insertafter: 'totem {'
   register: config_updated
   when:
     - ansible_check_mode

--- a/runner/ansible/roles/checks/1.1.2/tasks/main.yml
+++ b/runner/ansible/roles/checks/1.1.2/tasks/main.yml
@@ -3,9 +3,10 @@
 - name: "{{ name }}.check"
   lineinfile:
     path: /etc/corosync/corosync.conf
-    regexp: '^(\s+){{ key_name }}:'
-    line: "\t{{ key_name }}: {{ expected[name] }}"
-    insertafter: 'totem {'
+    regexp: '^(\s*){{ key_name }}:(\s*)\S*(\s)*$'
+    line: '\g<1>{{ key_name }}:\g<2>{{ expected[name] }}\g<3>'
+    backrefs: yes
+    #insertafter: 'totem {'
   register: config_updated
   when: ansible_check_mode
 

--- a/runner/ansible/roles/checks/1.1.3/tasks/main.yml
+++ b/runner/ansible/roles/checks/1.1.3/tasks/main.yml
@@ -3,9 +3,10 @@
 - name: "{{ name }}.check"
   lineinfile:
     path: /etc/corosync/corosync.conf
-    regexp: '^(\s+){{ key_name }}:'
-    line: "\t{{ key_name }}: {{ expected[name] }}"
-    insertafter: 'totem {'
+    regexp: '^(\s*){{ key_name }}:(\s*)\S*(\s)*$'
+    line: '\g<1>{{ key_name }}:\g<2>{{ expected[name] }}\g<3>'
+    backrefs: yes
+    #insertafter: 'totem {'
   register: config_updated
   when: ansible_check_mode
 

--- a/runner/ansible/roles/checks/1.1.4/tasks/main.yml
+++ b/runner/ansible/roles/checks/1.1.4/tasks/main.yml
@@ -3,9 +3,10 @@
 - name: "{{ name }}.check"
   lineinfile:
     path: /etc/corosync/corosync.conf
-    regexp: '^(\s+){{ key_name }}:'
-    line: "\t{{ key_name }}: {{ expected[name] }}"
-    insertafter: 'totem {'
+    regexp: '^(\s*){{ key_name }}:(\s*)\S*(\s)*$'
+    line: '\g<1>{{ key_name }}:\g<2>{{ expected[name] }}\g<3>'
+    backrefs: yes
+    #insertafter: 'totem {'
   register: config_updated
   when: ansible_check_mode
 

--- a/runner/ansible/roles/checks/1.1.5/tasks/main.yml
+++ b/runner/ansible/roles/checks/1.1.5/tasks/main.yml
@@ -3,9 +3,10 @@
 - name: "{{ name }}.check"
   lineinfile:
     path: /etc/corosync/corosync.conf
-    regexp: '^(\s+){{ key_name }}:'
-    line: "\t{{ key_name }}: {{ expected[name] }}"
-    insertafter: 'totem {'
+    regexp: '^(\s*){{ key_name }}:(\s*)\S*(\s)*$'
+    line: '\g<1>{{ key_name }}:\g<2>{{ expected[name] }}\g<3>'
+    backrefs: yes
+    #insertafter: 'totem {'
   register: config_updated
   when: ansible_check_mode
 

--- a/runner/ansible/roles/checks/1.1.6/tasks/main.yml
+++ b/runner/ansible/roles/checks/1.1.6/tasks/main.yml
@@ -3,9 +3,10 @@
 - name: "{{ name }}.check"
   lineinfile:
     path: /etc/corosync/corosync.conf
-    regexp: '^(\s+){{ key_name }}:'
-    line: "\t{{ key_name }}: {{ expected[name] }}"
-    insertafter: 'totem {'
+    regexp: '^(\s*){{ key_name }}:(\s*)\S*(\s)*$'
+    line: '\g<1>{{ key_name }}:\g<2>{{ expected[name] }}\g<3>'
+    backrefs: yes
+    #insertafter: 'totem {'
   register: config_updated
   when: ansible_check_mode
 

--- a/runner/ansible/roles/checks/1.1.7/tasks/main.yml
+++ b/runner/ansible/roles/checks/1.1.7/tasks/main.yml
@@ -3,9 +3,10 @@
 - name: "{{ name }}.check"
   lineinfile:
     path: /etc/corosync/corosync.conf
-    regexp: '^(\s+){{ key_name }}:'
-    line: "\t{{ key_name }}: {{ expected[name] }}"
-    insertafter: 'quorum {'
+    regexp: '^(\s*){{ key_name }}:(\s*)\S*(\s)*$'
+    line: '\g<1>{{ key_name }}:\g<2>{{ expected[name] }}\g<3>'
+    backrefs: yes
+    #insertafter: 'quorum {'
   register: config_updated
   when: ansible_check_mode
 

--- a/runner/ansible/roles/checks/1.1.8/tasks/main.yml
+++ b/runner/ansible/roles/checks/1.1.8/tasks/main.yml
@@ -3,9 +3,10 @@
 - name: "{{ name }}.check"
   lineinfile:
     path: /etc/corosync/corosync.conf
-    regexp: '^(\s+){{ key_name }}:'
-    line: "\t{{ key_name }}: {{ expected[name] }}"
-    insertafter: 'quorum {'
+    regexp: '^(\s*){{ key_name }}:(\s*)\S*(\s)*$'
+    line: '\g<1>{{ key_name }}:\g<2>{{ expected[name] }}\g<3>'
+    backrefs: yes
+    #insertafter: 'quorum {'
   register: config_updated
   when: ansible_check_mode
 

--- a/runner/ansible/roles/checks/1.3.1/tasks/main.yml
+++ b/runner/ansible/roles/checks/1.3.1/tasks/main.yml
@@ -1,10 +1,12 @@
 ---
 
 - name: "{{ name }}.check"
-  lineinfile:
-    path: /etc/sysconfig/sbd
-    regexp: '^SBD_PACEMAKER='
-    line: 'SBD_PACEMAKER={{ expected[name] }}'
+  check_mode: false
+  shell: |
+      #!/bin/bash
+      source /etc/sysconfig/sbd || exit 1
+      [ "${SBD_PACEMAKER}" == '{{ expected[name] }}' ] || exit 1
+      exit 0
   register: config_updated
   when:
     - ansible_check_mode

--- a/runner/ansible/roles/checks/1.3.2/tasks/main.yml
+++ b/runner/ansible/roles/checks/1.3.2/tasks/main.yml
@@ -1,10 +1,12 @@
 ---
 
 - name: "{{ name }}.check"
-  lineinfile:
-    path: /etc/sysconfig/sbd
-    regexp: '^SBD_STARTMODE='
-    line: 'SBD_STARTMODE={{ expected[name] }}'
+  check_mode: false
+  shell: |
+      #!/bin/bash
+      source /etc/sysconfig/sbd || exit 1
+      [ "${SBD_STARTMODE}" == '{{ expected[name] }}' ] || exit 1
+      exit 0
   register: config_updated
   when:
     - ansible_check_mode


### PR DESCRIPTION
Fixes  trento-project/trento/#/890

- fixing regex strings for Ansible
- using a different method for SBD config verification
The new regex would allow spaces and tab's in front of a line. It would ignore lines that are starting with a # (comment line).
The checks 1.3.1 and 1.3.2 we have decided to use sourcing the file and do the comparison on that result due to the fact systemd is handling the file in the same way.


This PR should fix the situation we saw at issue:
https://github.com/trento-project/trento/issues/890

Co-authored-by: scmschmidt