### PR TITLE
change static value of msgwait to 2 times of watchdog

### DIFF
--- a/runner/ansible/roles/checks/1.3.5/tasks/main.yml
+++ b/runner/ansible/roles/checks/1.3.5/tasks/main.yml
@@ -4,16 +4,25 @@
   shell: |
     DEF_WDTIMEOUT={{ expected[name] }}
     result_wdtimeout=${DEF_WDTIMEOUT}
-    sbdarray=$(grep -E '^SBD_DEVICE=' /etc/sysconfig/sbd  | grep -oP 'SBD_DEVICE=\K[^.]+' | sed 's/\"//g')
-    IFS=';' sbdarray=( $sbdarray )
+
+    if [ -f /etc/sysconfig/sbd ]; then
+      source /etc/sysconfig/sbd
+    else
+      exit 1
+    fi
+
+    IFS=';' sbdarray=( $SBD_DEVICE )
+
     for i in "${sbdarray[@]}"
     do
-      wdtimeout=$(/usr/sbin/sbd -d ${i} dump | grep -oP 'Timeout \(watchdog\)  *: \K\d+')|| echo ""
+      device="${i//[[:space:]]/}"
+      wdtimeout=$(/usr/sbin/sbd -d ${device} dump | grep -oP 'Timeout \(watchdog\)  *: \K\d+')|| echo ""
       if [[ "${wdtimeout}" -ne "${DEF_WDTIMEOUT}" ]]; then
         result_wdtimeout="${wdtimeout}"
       fi
     done
     echo "${result_wdtimeout}"
+
   check_mode: false
   register: config_updated
   changed_when: config_updated.stdout != expected[name]
@@ -26,3 +35,4 @@
     - ansible_check_mode
   vars:
     status: "{{ config_updated is not changed }}"
+

--- a/runner/ansible/roles/checks/1.3.6/tasks/main.yml
+++ b/runner/ansible/roles/checks/1.3.6/tasks/main.yml
@@ -2,21 +2,32 @@
 
 - name: "{{ name }}.check"
   shell: |
-    DEF_MSGWAIT={{ expected[name] }}
-    result_msgwait=${DEF_MSGWAIT}
-    sbdarray=$(grep -E '^SBD_DEVICE=' /etc/sysconfig/sbd  | grep -oP 'SBD_DEVICE=\K[^.]+' | sed 's/\"//g')
-    IFS=';' sbdarray=( $sbdarray )
+    if [ -f /etc/sysconfig/sbd ]; then
+      source /etc/sysconfig/sbd
+    else
+      exit 1
+    fi
+
+    IFS=';' sbdarray=( $SBD_DEVICE )
+
     for i in "${sbdarray[@]}"
-    do
-      msgwait=$(/usr/sbin/sbd -d ${i} dump | grep -oP 'Timeout \(msgwait\)  *: \K\d+')|| echo ""
-      if [[ "${msgwait}" -ne "${DEF_MSGWAIT}" ]]; then
-        result_msgwait="${msgwait}"
-      fi
-    done
-    echo $result_msgwait
+      do
+        device="${i//[[:space:]]/}"
+        msgwait=$(/usr/sbin/sbd -d ${device} dump | grep -oP 'Timeout \(msgwait\)  *: \K\d+')|| echo ""
+        watchdog=$(/usr/sbin/sbd -d ${device} dump | grep -oP 'Timeout \(watchdog\)  *: \K\d+')|| echo ""
+        declare -i msgwait
+        declare -i watchdog
+        let watchdog*=2
+        if [ $msgwait -lt $watchdog ]; then
+          exit 1
+        fi
+      done
+    exit 0
+
   register: config_updated
   check_mode: false
-  changed_when: config_updated.stdout != expected[name]
+  changed_when: config_updated.rc != 0
+  failed_when: config_updated.rc > 1
 
 - block:
     - name: Post results
@@ -26,3 +37,6 @@
     - ansible_check_mode
   vars:
     status: "{{ config_updated is not changed }}"
+
+
+


### PR DESCRIPTION
The original check is only checking if the values is equal to the expected[name]. 

The subject of this check is however to probe if msgwait 2 times or higher of watchdog:

   SBD msgwait timeout value is at least two times the watchdog timeout

