### PR TITLE
Fix 1.2.2

### DIFF
--- a/runner/ansible/roles/checks/1.3.4/tasks/main.yml
+++ b/runner/ansible/roles/checks/1.3.4/tasks/main.yml
@@ -2,15 +2,26 @@
 
 - name: "{{ name }}.check"
   shell: |
-    sbdarray=$(grep -E '^SBD_DEVICE=' /etc/sysconfig/sbd  | grep -oP 'SBD_DEVICE=\K[^.]+' | sed 's/\"//g')
-    IFS=';' sbdarray=( $sbdarray )
-    # convoluted, but normal count method does not work with jinja2
-    # issue: https://github.com/ansible/ansible/issues/16968
-    temp_ar=(${!sbdarray[@]});  device_count=`expr ${temp_ar[-1]} + 1`
-    echo "$device_count"
+    #!/bin/bash
+    file="/etc/sysconfig/sbd"
+    source "$file" || exit 1
+    COUNT=$(perl -e '
+          my $sbd_device="'$SBD_DEVICE'";
+          my $count;
+          my @paths=split(";", $sbd_device);
+          if ( $paths[-1] ne "" ) {
+              $count = $#paths + 1;
+          } else {
+              $count = $#paths;
+          }
+          printf "%i\n",  $count
+        ')
+    [[ "${COUNT}" == {{ expected[name] }} ]] && exit 0
+    exit 1
   check_mode: false
   register: config_updated
-  changed_when: config_updated.stdout != expected[name]
+  changed_when: config_updated.rc != 0
+  failed_when: config_updated.rc > 1
 
 - block:
     - name: Post results

--- a/runner/ansible/vars/dev/10-default.yml
+++ b/runner/ansible/vars/dev/10-default.yml
@@ -14,7 +14,7 @@ expected_core:
   "1.2.2.fence_azure_arm": "" # doesn't apply
   "1.3.1": "yes"
   "1.3.2": "clean"
-  "1.3.4": "1"
+  "1.3.4": "3"
   "1.3.5": "15"
   "1.3.6": "30"
   "2.2.1": "SLES_SAP"


### PR DESCRIPTION
Additional fix for 1.2.2 (and previously for 1.3.4).
Check for sbd stonith-timeout now also accepts >= values.