### PR TITLE
Set failed check executions as critical

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ADD . /build
 RUN zypper -n in git-core && make build
 
 FROM registry.suse.com/bci/python:3.9 AS trento-runner
-RUN /usr/bin/python3 -m venv /venv \
+RUN /usr/local/bin/python3 -m venv /venv \
     && /venv/bin/pip install 'ansible~=4.6.0' 'requests~=2.26.0' 'rpm==0.0.2' 'pyparsing~=2.0' \
     && zypper -n ref && zypper -n in --no-recommends openssh \
     && zypper -n clean

--- a/runner/ansible/callback_plugins/trento.py
+++ b/runner/ansible/callback_plugins/trento.py
@@ -243,7 +243,7 @@ class CallbackModule(CallbackBase):
 
         msg = result._check_key("msg")
         self.execution_results.add_host(host, True)
-        self.execution_results.add_result(host, task_vars[CHECK_ID], "warning", msg)
+        self.execution_results.add_result(host, task_vars[CHECK_ID], "critical", msg)
 
     def v2_runner_on_skipped(self, result):
         """

--- a/runner/ansible/callback_plugins/trento.py
+++ b/runner/ansible/callback_plugins/trento.py
@@ -138,10 +138,12 @@ class Host(object):
         """
         Add check result
         """
+        # Check if a result already exists
+        # Due how ansible callbacks system works, we might get same check results twice
+        # where the 2nd result is false, as it gives the results of `set_test_result` task
+        # when the check has failed due abnormal behaviours
         for result_item in self.results:
             if result_item.check_id == check_id:
-                result_item.result = result
-                result_item.msg = msg
                 break
         else:
             self.results.append(CheckResult(check_id, result, msg))


### PR DESCRIPTION
Due the way ansible handle callbacks, the code was overwriting some check results, when the ansible task was failing abnormally (for example, when the checked file in some checks don't exist).
This change disables the overwritting.

Besides that, I have changed the check result to a `critical` state in this case, rather than `warning`, as it looks something worth checking. What do you think @abravosuse ?

By now, we don't display the error message in the frontend, but in this cases we send it to the server, so at some point we could show it.