### PR TITLE
Pass json list in quotes

### DIFF
--- a/runner/inventory.go
+++ b/runner/inventory.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path"
 	"text/template"
@@ -78,7 +79,7 @@ func NewClusterInventoryContent(e *ExecutionEvent) (*InventoryContent, error) {
 			Variables:   make(map[string]interface{}),
 		}
 
-		node.Variables[clusterSelectedChecks] = string(jsonChecks)
+		node.Variables[clusterSelectedChecks] = fmt.Sprintf("'%s'", string(jsonChecks))
 		node.Variables[provider] = e.Provider
 
 		nodes = append(nodes, node)

--- a/runner/inventory_test.go
+++ b/runner/inventory_test.go
@@ -125,7 +125,7 @@ func (suite *InventoryTestSuite) Test_NewClusterInventoryContent() {
 					&Node{
 						Name: host1.String(),
 						Variables: map[string]interface{}{
-							"cluster_selected_checks": "[\"check1\",\"check2\"]",
+							"cluster_selected_checks": "'[\"check1\",\"check2\"]'",
 							"provider":                "azure",
 						},
 						AnsibleHost: "192.168.10.1",
@@ -134,7 +134,7 @@ func (suite *InventoryTestSuite) Test_NewClusterInventoryContent() {
 					&Node{
 						Name: host2.String(),
 						Variables: map[string]interface{}{
-							"cluster_selected_checks": "[\"check1\",\"check2\"]",
+							"cluster_selected_checks": "'[\"check1\",\"check2\"]'",
 							"provider":                "azure",
 						},
 						AnsibleHost: "192.168.10.2",

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -232,8 +232,8 @@ func (suite *RunnerTestCase) Test_NewAnsibleCheckRunner() {
 	inventoryContent, err := ioutil.ReadFile(inventoryFile)
 	expectedFile := "\n" +
 		"[%s]\n" +
-		"%s ansible_host=192.168.10.1 ansible_user=user1 cluster_selected_checks=[\"check1\",\"check2\"] provider=azure \n" +
-		"%s ansible_host=192.168.10.2 ansible_user=user2 cluster_selected_checks=[\"check1\",\"check2\"] provider=azure \n"
+		"%s ansible_host=192.168.10.1 ansible_user=user1 cluster_selected_checks='[\"check1\",\"check2\"]' provider=azure \n" +
+		"%s ansible_host=192.168.10.2 ansible_user=user2 cluster_selected_checks='[\"check1\",\"check2\"]' provider=azure \n"
 
 	suite.NoError(err)
 	suite.Equal(expectedChecksRunner, a)


### PR DESCRIPTION
The `cluster_selected_checks` was not being set totally correct, as it was not a list. In order to pass as a real json, we need to use quotes.
For reference: https://docs.ansible.com/ansible/latest/user_guide/playbooks_variables.html#json-string-format

This way, the value is set as `["check_id", "check_id"]`, as a list of strings
Otherwise is set as `"[check_id, check_id]"`, as a string instead of a list