### PR TITLE
Include suse container packaging

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -11,10 +11,6 @@ on:
     types: [published]
   workflow_dispatch:
 
-env:
-  REPOSITORY: ${{ github.repository }}
-  IMAGE_NAME: trento-runner-new
-
 jobs:
   test-binary:
     runs-on: ubuntu-20.04
@@ -220,3 +216,69 @@ jobs:
         with:
           files: "trento-runner-*"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+  obs-commit:
+    name: Commit the project on OBS
+    runs-on: ubuntu-20.04
+    if: github.event_name == 'release' || (github.event_name == 'push' && github.ref_name == 'main') || github.event_name == 'workflow_dispatch'
+    needs: [test-binary, test-checks, test-python-callback]
+    container:
+      image: ghcr.io/trento-project/continuous-delivery:master
+      env:
+        GITHUB_OAUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        DEST_FOLDER: "/tmp/osc_project"
+        PACKAGE_NAME: trento-runner-image
+        OBS_USER: ${{ secrets.OBS_USER }}
+        OBS_PASS: ${{ secrets.OBS_PASS }}
+        OBS_PROJECT: ${{ secrets.OBS_PROJECT }}
+        FOLDER: packaging/suse
+        REPOSITORY: ${{ github.repository }}
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          access_token: ${{ github.token }}
+
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Prepare .changes file
+        # The .changes file is updated only in release creation. This current task should be improved
+        # in order to add the current rolling release notes
+        if: github.event_name == 'release'
+        run: |
+          CHANGES_FILE=$PACKAGE_NAME.changes
+          osc checkout $OBS_PROJECT $PACKAGE_NAME $CHANGES_FILE
+          mv $CHANGES_FILE $FOLDER
+          VERSION=$(./hack/get_version_from_git.sh)
+          TAG=$(echo $VERSION | cut -f1 -d+)
+          hack/gh_release_to_obs_changeset.py $REPOSITORY -a shap-staff@suse.de -t $TAG -f $FOLDER/$CHANGES_FILE
+
+      - name: Set version
+        run: |
+          VERSION=$(./hack/get_version_from_git.sh)
+          sed -i 's~%%REVISION%%~${{ github.sha }}~' $FOLDER/_service && \
+          sed -i 's~%%REPOSITORY%%~${{ github.repository }}~' $FOLDER/_service && \
+          sed -i 's~%%VERSION%%~'"${VERSION}"'~' $FOLDER/_service && \
+          sed -i 's~%%VERSION%%~'"${VERSION}"'~' $FOLDER/Dockerfile
+
+      - name: Configure OSC
+        # OSC credentials must be configured beforehand as the HOME variables cannot be changed from /github/home
+        # that is used to run osc commands
+        run: |
+          /scripts/init_osc_creds.sh
+          mkdir -p $HOME/.config/osc
+          cp /root/.config/osc/oscrc $HOME/.config/osc
+
+      - name: Commit on OBS
+        run: |
+          OBS_PACKAGE=$OBS_PROJECT/$PACKAGE_NAME
+          osc checkout $OBS_PACKAGE -o $DEST_FOLDER
+          cp -r packaging/suse/* $DEST_FOLDER
+          cd $DEST_FOLDER
+          osc rm -f ./*.tar.*
+          osc service dr
+          osc ar
+          osc commit -m "New development version of $PACKAGE_NAME released"

--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -241,8 +241,12 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v3
+
+      - uses: actions-ecosystem/action-get-latest-tag@v1
+        id: latest-tag
         with:
-          fetch-depth: 0
+          semver_only: true
+          initial_version: 0.0.1
 
       - name: Prepare .changes file
         # The .changes file is updated only in release creation. This current task should be improved
@@ -252,18 +256,16 @@ jobs:
           CHANGES_FILE=$PACKAGE_NAME.changes
           osc checkout $OBS_PROJECT $PACKAGE_NAME $CHANGES_FILE
           mv $CHANGES_FILE $FOLDER
-          VERSION=$(./hack/get_version_from_git.sh)
-          TAG=$(echo $VERSION | cut -f1 -d+)
-          hack/gh_release_to_obs_changeset.py $REPOSITORY -a shap-staff@suse.de -t $TAG -f $FOLDER/$CHANGES_FILE
+          VERSION=${{ steps.latest-tag.outputs.tag }}
+          hack/gh_release_to_obs_changeset.py $REPOSITORY -a shap-staff@suse.de -t $VERSION -f $FOLDER/$CHANGES_FILE
 
       - name: Set version
         run: |
-          VERSION=$(./hack/get_version_from_git.sh)
-          TAG=$(echo $VERSION | cut -f1 -d+)
+          VERSION=${{ steps.latest-tag.outputs.tag }}
           sed -i 's~%%REVISION%%~${{ github.sha }}~' $FOLDER/_service && \
           sed -i 's~%%REPOSITORY%%~${{ github.repository }}~' $FOLDER/_service && \
-          sed -i 's~%%VERSION%%~'"${TAG}"'~' $FOLDER/_service && \
-          sed -i 's~%%VERSION%%~'"${TAG}"'~' $FOLDER/Dockerfile
+          sed -i 's~%%VERSION%%~'"${VERSION}"'~' $FOLDER/_service && \
+          sed -i 's~%%VERSION%%~'"${VERSION}"'~' $FOLDER/Dockerfile
 
       - name: Configure OSC
         # OSC credentials must be configured beforehand as the HOME variables cannot be changed from /github/home

--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -259,10 +259,11 @@ jobs:
       - name: Set version
         run: |
           VERSION=$(./hack/get_version_from_git.sh)
+          TAG=$(echo $VERSION | cut -f1 -d+)
           sed -i 's~%%REVISION%%~${{ github.sha }}~' $FOLDER/_service && \
           sed -i 's~%%REPOSITORY%%~${{ github.repository }}~' $FOLDER/_service && \
-          sed -i 's~%%VERSION%%~'"${VERSION}"'~' $FOLDER/_service && \
-          sed -i 's~%%VERSION%%~'"${VERSION}"'~' $FOLDER/Dockerfile
+          sed -i 's~%%VERSION%%~'"${TAG}"'~' $FOLDER/_service && \
+          sed -i 's~%%VERSION%%~'"${TAG}"'~' $FOLDER/Dockerfile
 
       - name: Configure OSC
         # OSC credentials must be configured beforehand as the HOME variables cannot be changed from /github/home

--- a/packaging/suse/Dockerfile
+++ b/packaging/suse/Dockerfile
@@ -1,0 +1,41 @@
+#!BuildTag: trento/trento-runner:latest
+#!BuildTag: trento/trento-runner:%%VERSION%%
+#!BuildTag: trento/trento-runner:%%VERSION%%-build%RELEASE%
+FROM bci/bci-base:15.3
+
+# Define labels according to https://en.opensuse.org/Building_derived_containers
+# labelprefix=com.suse.trento
+PREFIXEDLABEL org.opencontainers.image.title="Trento runner"
+PREFIXEDLABEL org.opencontainers.image.description="This contains trento runner %%VERSION%%"
+PREFIXEDLABEL org.opensuse.reference="registry.suse.com/trento/trento-runner:%%VERSION%%"
+PREFIXEDLABEL org.openbuildservice.disturl="%DISTURL%"
+PREFIXEDLABEL org.opencontainers.image.created="%BUILDTIME%"
+
+# Workaround for https://github.com/openSUSE/obs-build/issues/487
+RUN zypper --non-interactive in sles-release
+RUN zypper --non-interactive in tar gzip make go
+
+COPY runner-%%VERSION%%.tar.gz premium-checks.tar.gz* /build/
+COPY vendor.tar.gz /build/
+
+WORKDIR /build/
+RUN tar -xvzf runner-%%VERSION%%.tar.gz
+RUN tar -xvzf vendor.tar.gz -C runner-%%VERSION%%/
+
+# The next RUN only works if the premium-checks.tar.gz file is present
+RUN tar --transform 'flags=r;s/^premium-checks//' -xvzf premium-checks.tar.gz -C runner-%%VERSION%%/ || true
+
+WORKDIR /build/runner-%%VERSION%%
+RUN VERSION=%%VERSION%% FLAVOR=Premium make build
+RUN cp /build/runner-%%VERSION%%/trento-runner /usr/bin/trento-runner
+
+# Install Ansible dependecies
+RUN zypper --non-interactive in openssh python3 python3-rpm python3-requests python3-PyYAML python3-Jinja2 ansible-core tini
+
+# Temporary solution until we have ansible-4.6.0 packaged in IBS
+COPY ansible-4.6.0.tar.gz /tmp/ansible-4.6.0.tar.gz
+RUN zypper --non-interactive in python3-pip
+RUN pip install --no-index --find-links /tmp /tmp/ansible-4.6.0.tar.gz
+
+LABEL org.opencontainers.image.source="https://github.com/trento-project/runner"
+ENTRYPOINT ["/tini", "--", "/usr/bin/trento-runner"]

--- a/packaging/suse/_service
+++ b/packaging/suse/_service
@@ -1,0 +1,20 @@
+<services>
+  <service mode="buildtime" name="docker_label_helper"/>
+  <service mode="buildtime" name="kiwi_metainfo_helper"/>
+  <service name="tar_scm" mode="disabled">
+      <param name="url">https://github.com/%%REPOSITORY%%.git</param>
+      <param name="scm">git</param>
+      <param name="revision">%%REVISION%%</param>
+      <param name="exclude">.git</param>
+      <param name="exclude">.github</param>
+      <param name="versionformat">%%VERSION%%</param>
+      <param name="filename">runner</param>
+  </service>
+  <service name="recompress" mode="disabled">
+      <param name="file">*.tar</param>
+      <param name="compression">gz</param>
+  </service>
+  <service name="go_modules" mode="disabled">
+      <param name="archive">runner-%%VERSION%%.tar.gz</param>
+  </service>
+</services>


### PR DESCRIPTION
Include suse packaging files for the runner container. It enables the CI to push to OBS as well (and in a while, we would mirror this container in IBS).

The major particularity of the Dockerfile is that depending on the `premium-checks.tar.gz` file is present or not in the OBS package, It will add these files to the container or not.

By now, it will ship the container in: https://build.opensuse.org/package/show/devel:sap:trento:factory/trento-runner-image

The last commit includes a fix for the git CVE-2022-24765. More info in:
https://github.blog/2022-04-12-git-security-vulnerability-announced/
https://github.com/actions/checkout/issues/760