### PR TITLE
Fix corosync file regexp to be more robust

### DIFF
--- a/runner/ansible/roles/checks/1.1.2/tasks/main.yml
+++ b/runner/ansible/roles/checks/1.1.2/tasks/main.yml
@@ -3,11 +3,11 @@
 - name: "{{ name }}.check"
   lineinfile:
     path: /etc/corosync/corosync.conf
-    regexp: '^(\s*){{ key_name }}:(\s*)\S*(\s)*$'
-    line: '\g<1>{{ key_name }}:\g<2>{{ expected[name] }}\g<3>'
-    backrefs: yes
-    #insertafter: 'totem {'
-  register: config_updated
+    regexp: '^\s*{{ key_name }}:\s*{{ expected[name] }}\s*$'
+    state: absent
+  register: result
+  check_mode: true
+  changed_when: false
   when: ansible_check_mode
 
 - block:
@@ -17,4 +17,4 @@
   when:
     - ansible_check_mode
   vars:
-    status: "{{ config_updated is not changed }}"
+    status: "{{ result.found|default(false) | ternary(true, false) }}"

--- a/runner/ansible/roles/checks/1.1.3/tasks/main.yml
+++ b/runner/ansible/roles/checks/1.1.3/tasks/main.yml
@@ -3,11 +3,11 @@
 - name: "{{ name }}.check"
   lineinfile:
     path: /etc/corosync/corosync.conf
-    regexp: '^(\s*){{ key_name }}:(\s*)\S*(\s)*$'
-    line: '\g<1>{{ key_name }}:\g<2>{{ expected[name] }}\g<3>'
-    backrefs: yes
-    #insertafter: 'totem {'
-  register: config_updated
+    regexp: '^\s*{{ key_name }}:\s*{{ expected[name] }}\s*$'
+    state: absent
+  register: result
+  check_mode: true
+  changed_when: false
   when: ansible_check_mode
 
 - block:
@@ -17,4 +17,4 @@
   when:
     - ansible_check_mode
   vars:
-    status: "{{ config_updated is not changed }}"
+    status: "{{ result.found|default(false) | ternary(true, false) }}"

--- a/runner/ansible/roles/checks/1.1.4/tasks/main.yml
+++ b/runner/ansible/roles/checks/1.1.4/tasks/main.yml
@@ -3,11 +3,11 @@
 - name: "{{ name }}.check"
   lineinfile:
     path: /etc/corosync/corosync.conf
-    regexp: '^(\s*){{ key_name }}:(\s*)\S*(\s)*$'
-    line: '\g<1>{{ key_name }}:\g<2>{{ expected[name] }}\g<3>'
-    backrefs: yes
-    #insertafter: 'totem {'
-  register: config_updated
+    regexp: '^\s*{{ key_name }}:\s*{{ expected[name] }}\s*$'
+    state: absent
+  register: result
+  check_mode: true
+  changed_when: false
   when: ansible_check_mode
 
 - block:
@@ -17,4 +17,4 @@
   when:
     - ansible_check_mode
   vars:
-    status: "{{ config_updated is not changed }}"
+    status: "{{ result.found|default(false) | ternary(true, false) }}"

--- a/runner/ansible/roles/checks/1.1.5/tasks/main.yml
+++ b/runner/ansible/roles/checks/1.1.5/tasks/main.yml
@@ -3,11 +3,11 @@
 - name: "{{ name }}.check"
   lineinfile:
     path: /etc/corosync/corosync.conf
-    regexp: '^(\s*){{ key_name }}:(\s*)\S*(\s)*$'
-    line: '\g<1>{{ key_name }}:\g<2>{{ expected[name] }}\g<3>'
-    backrefs: yes
-    #insertafter: 'totem {'
-  register: config_updated
+    regexp: '^\s*{{ key_name }}:\s*{{ expected[name] }}\s*$'
+    state: absent
+  register: result
+  check_mode: true
+  changed_when: false
   when: ansible_check_mode
 
 - block:
@@ -17,4 +17,4 @@
   when:
     - ansible_check_mode
   vars:
-    status: "{{ config_updated is not changed }}"
+    status: "{{ result.found|default(false) | ternary(true, false) }}"

--- a/runner/ansible/roles/checks/1.1.6/tasks/main.yml
+++ b/runner/ansible/roles/checks/1.1.6/tasks/main.yml
@@ -3,11 +3,11 @@
 - name: "{{ name }}.check"
   lineinfile:
     path: /etc/corosync/corosync.conf
-    regexp: '^(\s*){{ key_name }}:(\s*)\S*(\s)*$'
-    line: '\g<1>{{ key_name }}:\g<2>{{ expected[name] }}\g<3>'
-    backrefs: yes
-    #insertafter: 'totem {'
-  register: config_updated
+    regexp: '^\s*{{ key_name }}:\s*{{ expected[name] }}\s*$'
+    state: absent
+  register: result
+  check_mode: true
+  changed_when: false
   when: ansible_check_mode
 
 - block:
@@ -17,4 +17,4 @@
   when:
     - ansible_check_mode
   vars:
-    status: "{{ config_updated is not changed }}"
+    status: "{{ result.found|default(false) | ternary(true, false) }}"

--- a/runner/ansible/roles/checks/1.1.7/tasks/main.yml
+++ b/runner/ansible/roles/checks/1.1.7/tasks/main.yml
@@ -3,11 +3,11 @@
 - name: "{{ name }}.check"
   lineinfile:
     path: /etc/corosync/corosync.conf
-    regexp: '^(\s*){{ key_name }}:(\s*)\S*(\s)*$'
-    line: '\g<1>{{ key_name }}:\g<2>{{ expected[name] }}\g<3>'
-    backrefs: yes
-    #insertafter: 'quorum {'
-  register: config_updated
+    regexp: '^\s*{{ key_name }}:\s*{{ expected[name] }}\s*$'
+    state: absent
+  register: result
+  check_mode: true
+  changed_when: false
   when: ansible_check_mode
 
 - block:
@@ -17,4 +17,4 @@
   when:
     - ansible_check_mode
   vars:
-    status: "{{ config_updated is not changed }}"
+    status: "{{ result.found|default(false) | ternary(true, false) }}"

--- a/runner/ansible/roles/checks/1.1.8/tasks/main.yml
+++ b/runner/ansible/roles/checks/1.1.8/tasks/main.yml
@@ -3,11 +3,11 @@
 - name: "{{ name }}.check"
   lineinfile:
     path: /etc/corosync/corosync.conf
-    regexp: '^(\s*){{ key_name }}:(\s*)\S*(\s)*$'
-    line: '\g<1>{{ key_name }}:\g<2>{{ expected[name] }}\g<3>'
-    backrefs: yes
-    #insertafter: 'quorum {'
-  register: config_updated
+    regexp: '^\s*{{ key_name }}:\s*{{ expected[name] }}\s*$'
+    state: absent
+  register: result
+  check_mode: true
+  changed_when: false
   when: ansible_check_mode
 
 - block:
@@ -17,4 +17,4 @@
   when:
     - ansible_check_mode
   vars:
-    status: "{{ config_updated is not changed }}"
+    status: "{{ result.found|default(false) | ternary(true, false) }}"

--- a/runner/ansible/roles/post-results/tasks/main.yml
+++ b/runner/ansible/roles/post-results/tasks/main.yml
@@ -5,3 +5,8 @@
   set_fact:
     test_result: "{{ (status == true) | ternary('passing', on_failure | default('critical')) }}"
   delegate_to: localhost
+
+- name: print_result
+  debug:
+    msg: "Result for {{ name }}: {{ test_result }}"
+  delegate_to: localhost


### PR DESCRIPTION
Fix corosync file content checks to be more robust.

Changed how the matching is done. The previous code was designed to apply remediation too, but it was too weak to find many scenarios (specially, when the line was not there at all). As we don't aim for remediation by now, this covers much more scenarios.

It fixes the the issues where:
- There is a trailling whitespace/tab at the end of the line (in the file the tab is not visible, but it might be there -> passing
- Comment at the beginning of match -> critical
- Line doesn't exist at all -> critical
- Char after match (example: `max_messages: 20 a`) -> critical

Besides that, I have added a small debugging state which prints the last check result.

```
TASK [/tmp/trento/ansible/roles/checks/1.1.1 : 1.1.1.check] ***************************************************************************
ok: [test]

TASK [post-results : set_test_result] *************************************************************************************************
ok: [test -> localhost]

TASK [post-results : print_result] ****************************************************************************************************
ok: [test -> localhost] => {
    "msg": "Result for 1.1.1: passing"
}

TASK [/tmp/trento/ansible/roles/checks/1.1.2 : 1.1.2.check] ***************************************************************************
ok: [test]

TASK [post-results : set_test_result] *************************************************************************************************
ok: [test -> localhost]

TASK [post-results : print_result] ****************************************************************************************************
ok: [test -> localhost] => {
    "msg": "Result for 1.1.2: critical"
}


```
