### PR TITLE
Fix inconsisten vendoring issue due the self replace

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/trento-project/runner
 
 go 1.16
 
-replace github.com/trento-project/runner => ./
-
 require (
 	github.com/gin-gonic/gin v1.7.7
 	github.com/google/uuid v1.3.0

--- a/packaging/suse/Dockerfile
+++ b/packaging/suse/Dockerfile
@@ -13,7 +13,7 @@ PREFIXEDLABEL org.opencontainers.image.created="%BUILDTIME%"
 
 # Workaround for https://github.com/openSUSE/obs-build/issues/487
 RUN zypper --non-interactive in sles-release
-RUN zypper --non-interactive in tar gzip make go
+RUN zypper --non-interactive in tar gzip make go1.16
 
 COPY runner-%%VERSION%%.tar.gz premium-checks.tar.gz* /build/
 COPY vendor.tar.gz /build/


### PR DESCRIPTION
Fix for in `go1.18` during the `make build` action:
```
go: inconsistent vendoring in /home/xarbulu/Workspace/sap_squad/trento-stack/runner:
	github.com/trento-project/runner: is marked as replaced in vendor/modules.txt, but not replaced in go.mod

	To ignore the vendor directory, use -mod=readonly or -mod=mod.
	To sync the vendor directory, run:
		go mod vendor
make: *** [Makefile:45: trento-runner] Error 1
```

Some related external discussions:
https://github.com/containerd/containerd/issues/6586
https://github.com/golang/go/issues/34417

Apparently the self replace thing is not supported anymore in golang 1.18, since it doesn't make many sense.
@stefanotorresi Could you have a special look on this, since I don't really know why we started having this thing in the code