### PR TITLE
added \s* whitespace between "token" and ":"

### DIFF
--- a/runner/ansible/roles/checks/1.1.1/tasks/main.yml
+++ b/runner/ansible/roles/checks/1.1.1/tasks/main.yml
@@ -17,7 +17,7 @@
         while ($cont =~ m/\btotem\s*{[^}]*}/gs) {
             my $totemStr=$&;
             # filter for key value pairs for token
-            if ($totemStr =~ /token:\s*(\S*)\s*/g) {         
+            if ($totemStr =~ /token\s*:\s*(\S*)\s*/g) {         
                 print "$1";
             }
         }


### PR DESCRIPTION
In one of the tests when space was added between "token" and ":", this check was failing. 
Adding whitespace "\s*" between "token" and ":" in the regular expression for the filter should fix this.