### PR TITLE
Workaround tar_scm issue that remove - char from version string

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -286,12 +286,13 @@ jobs:
         run: |
           git config --global --add safe.directory /__w/runner/runner
           VERSION=$(./hack/get_version_from_git.sh)
-          # "+" character is not allowed in OBS dockerfile version strings
-          VERSION=${VERSION//[+]/-}
           sed -i 's~%%REVISION%%~${{ github.sha }}~' $FOLDER/_service && \
           sed -i 's~%%REPOSITORY%%~${{ github.repository }}~' $FOLDER/_service && \
           sed -i 's~%%VERSION%%~'"${VERSION}"'~' $FOLDER/_service && \
           sed -i 's~%%VERSION%%~'"${VERSION}"'~' $FOLDER/Dockerfile
+          # "+" character is not allowed in OBS dockerfile version strings
+          VERSION=${VERSION//[+]/-}
+          sed -i 's~%%OBS_VERSION%%~'"${VERSION}"'~' $FOLDER/Dockerfile
 
       - name: Commit on OBS
         run: |

--- a/packaging/suse/Dockerfile
+++ b/packaging/suse/Dockerfile
@@ -1,6 +1,6 @@
 #!BuildTag: trento/trento-runner:latest
-#!BuildTag: trento/trento-runner:%%VERSION%%
-#!BuildTag: trento/trento-runner:%%VERSION%%-build%RELEASE%
+#!BuildTag: trento/trento-runner:%%OBS_VERSION%%
+#!BuildTag: trento/trento-runner:%%OBS_VERSION%%-build%RELEASE%
 FROM bci/bci-base:15.3
 
 # Define labels according to https://en.opensuse.org/Building_derived_containers


### PR DESCRIPTION
Apparently `-` character is illegal in `rpm` packages: https://github.com/openSUSE/obs-service-tar_scm/issues/367

So it looks like the `tar_scm` utility removes any `-` from the version. The things is that we don't use this service to create any rpm, we use it to create a docker container...

In order to workaround this, I just use now 2 version strings:
- One with the original `+`, which is used to create the dockerfile tarball and the container itself
- Other with the replaced `-`, which is only used to determine the version for the suse registry.

As a comment, unfortunately the `+` char is not allowed in suse registry containers version format...