### PR TITLE
Push modified version of dockerfile to obs

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -290,6 +290,7 @@ jobs:
         run: |
           osc checkout $OBS_PROJECT $PACKAGE_NAME -o $OSC_CHECKOUT_DIR
           cp $PACKAGE_DIR/_service $OSC_CHECKOUT_DIR
+          cp $PACKAGE_DIR/Dockerfile $OSC_CHECKOUT_DIR
           rm -v $OSC_CHECKOUT_DIR/{vendor,runner}*.tar.gz
           pushd $OSC_CHECKOUT_DIR
           osc service manualrun


### PR DESCRIPTION
If there is some future release. Now, we were simply copying the _service file, but the Dockerfile must be copied after being modified as well