### PR TITLE
Remove Azure mention in cross platform checks

### DIFF
--- a/runner/ansible/roles/checks/1.1.2.runtime/defaults/main.yml
+++ b/runner/ansible/roles/checks/1.1.2.runtime/defaults/main.yml
@@ -10,7 +10,7 @@ remediation: |
   The runtime value of the Corosync `consensus` timeout is not set as recommended.
 
   ## Remediation
-  Adjust the corosync `consensus` timeout as recommended by the Azure best practices, and reload the corosync service.
+  Adjust the corosync `consensus` timeout as recommended on the best practices, and reload the corosync service.
 
   ## References
   Azure:

--- a/runner/ansible/roles/checks/1.1.2/defaults/main.yml
+++ b/runner/ansible/roles/checks/1.1.2/defaults/main.yml
@@ -7,7 +7,7 @@ description: |
   Corosync `consensus` timeout is set to `{{ expected[name] }}`
 remediation: |
   ## Remediation
-  Adjust the Corosync `consensus` timeout as recommended by the Azure best practices.
+  Adjust the Corosync `consensus` timeout as recommended on the best practices.
 
   ## References
   Azure:

--- a/runner/ansible/roles/checks/1.1.3.runtime/defaults/main.yml
+++ b/runner/ansible/roles/checks/1.1.3.runtime/defaults/main.yml
@@ -10,7 +10,7 @@ remediation: |
   The runtime value of the Corosync `max_messages` parameter is not set as recommended.
 
   ## Remediation
-  Adjust the corosync `max_messages` parameter as recommended by the Azure best practices, and reload the corosync service.
+  Adjust the corosync `max_messages` parameter as recommended on the best practices, and reload the corosync service.
 
   ## References
   AZURE:

--- a/runner/ansible/roles/checks/1.1.3/defaults/main.yml
+++ b/runner/ansible/roles/checks/1.1.3/defaults/main.yml
@@ -7,7 +7,7 @@ description: |
   Corosync `max_messages` is set to `{{ expected[name] }}`
 remediation: |
   ## Remediation
-  Adjust the Corosync `max_messages` parameter as recommended by the Azure best practices.
+  Adjust the Corosync `max_messages` parameter as recommended on the best practices.
 
   ## References
   AZURE:

--- a/runner/ansible/roles/checks/1.1.4.runtime/defaults/main.yml
+++ b/runner/ansible/roles/checks/1.1.4.runtime/defaults/main.yml
@@ -10,7 +10,7 @@ remediation: |
   The runtime value of the Corosync `join` parameter is not set as recommended.
 
   ## Remediation
-  Adjust the corosync `join` parameter as recommended by the Azure best practices, and reload the corosync service.
+  Adjust the corosync `join` parameter as recommended on the best practices, and reload the corosync service.
 
   ## References
   AZURE:

--- a/runner/ansible/roles/checks/1.1.4/defaults/main.yml
+++ b/runner/ansible/roles/checks/1.1.4/defaults/main.yml
@@ -7,7 +7,7 @@ description: |
   Corosync `join` is set to `{{ expected[name] }}`
 remediation: |
   ## Remediation
-  Adjust the Corosync `join` parameter as recommended by the Azure best practices.
+  Adjust the Corosync `join` parameter as recommended on the best practices.
 
   ## References
   AZURE:

--- a/runner/ansible/roles/checks/1.1.5.runtime/defaults/main.yml
+++ b/runner/ansible/roles/checks/1.1.5.runtime/defaults/main.yml
@@ -10,7 +10,7 @@ remediation: |
   The runtime value of the corosync `token_retransmits_before_loss_const` parameter is not set as recommended
 
   ## Remediation
-  Adjust the corosync `token_retransmits_before_loss_const` parameter as recommended on the Azure best practices, and reload the corosync service.
+  Adjust the corosync `token_retransmits_before_loss_const` parameter as recommended on the best practices, and reload the corosync service.
 
   ## References
   AZURE:

--- a/runner/ansible/roles/checks/1.1.5/defaults/main.yml
+++ b/runner/ansible/roles/checks/1.1.5/defaults/main.yml
@@ -7,7 +7,7 @@ description: |
   Corosync `token_retransmits_before_loss_const` is set to: `{{ expected[name] }}`
 remediation: |
   ## Remediation
-  Adjust the corosync `token_retransmits_before_loss_const` parameter to `{{ expected[name] }}` as recommended by the Azure best practices.
+  Adjust the corosync `token_retransmits_before_loss_const` parameter to `{{ expected[name] }}` as recommended on the best practices.
 
   ## References
   AZURE:


### PR DESCRIPTION
Removing specific mention to Azure in remediation text for checks: 1.1.2, 1.1.2.runtime, 1.1.3, 1.1.3.runtime, 1.1.4, 1.1.4.runtime, 1.1.5, 1.1.5.runtime